### PR TITLE
Pull Request: Add 5-byte version of 0x321 SAM frame for CAN2010 compa…

### DIFF
--- a/arduino-psa-comfort-can-adapter/arduino-psa-comfort-can-adapter.ino
+++ b/arduino-psa-comfort-can-adapter/arduino-psa-comfort-can-adapter.ino
@@ -1536,6 +1536,17 @@ void loop() {
             CAN0.sendMessage( & canMsgSnd);
           }
         }
+          
+        // Intercept 0x321 and reconstruct it with 5 bytes DrumVlado
+        else if (id == 0x321 && len < 5)  { 
+        canMsgSnd.can_id = 0x321;  // Set CAN ID to 0x321
+        canMsgSnd.can_dlc = 5;     // Set length to 5 bytes
+        for (int i = 0; i < 4; i++) {
+        canMsgSnd.data[i] = canMsgRcv.data[i];  // Copy the first 4 bytes from the received message
+        }
+        canMsgSnd.data[4] = 0x00;  // Add the missing byte
+        CAN1.sendMessage(&canMsgSnd);
+          
       } else {
         CAN1.sendMessage( & canMsgRcv);
       }

--- a/arduino-psa-comfort-can-adapter/arduino-psa-comfort-can-adapter.ino
+++ b/arduino-psa-comfort-can-adapter/arduino-psa-comfort-can-adapter.ino
@@ -1536,17 +1536,14 @@ void loop() {
             CAN0.sendMessage( & canMsgSnd);
           }
         }
-          
-        // Intercept 0x321 and reconstruct it with 5 bytes DrumVlado
-        else if (id == 0x321 && len < 5)  { 
+      } else if (id == 0x321 && len < 5)  { // Intercept 0x321 and reconstruct it with 5 bytes DrumVlado
         canMsgSnd.can_id = 0x321;  // Set CAN ID to 0x321
         canMsgSnd.can_dlc = 5;     // Set length to 5 bytes
         for (int i = 0; i < 4; i++) {
-        canMsgSnd.data[i] = canMsgRcv.data[i];  // Copy the first 4 bytes from the received message
+          canMsgSnd.data[i] = canMsgRcv.data[i];  // Copy the first 4 bytes from the received message
         }
         canMsgSnd.data[4] = 0x00;  // Add the missing byte
         CAN1.sendMessage(&canMsgSnd);
-          
       } else {
         CAN1.sendMessage( & canMsgRcv);
       }


### PR DESCRIPTION
…tibility

On AEE2004 Citroen C5 (2004-2008) and Peugeot 407 systems (BSI2004), CAN ID 0x321 is sent with less than 5 bytes. This causes "hybrid system fault" and "passenger airbag fault" warning lights on newer CAN2010 clusters (CMB/CIRROCO). This fix pads the message to 5 bytes to restore compatibility. Tested on a 2007 CitroenC5 with no issues.
Credit: Many thanks to nico1080 - DS4-Cirocco Retrofit Project, where I found info on 0x321 frame to control SAM indicators.